### PR TITLE
fix(chat): update auth errors

### DIFF
--- a/pages/02.reference/01.chat/03.methods/01.auth/doc.md
+++ b/pages/02.reference/01.chat/03.methods/01.auth/doc.md
@@ -78,12 +78,7 @@ Authenticate as an active user in a specified channel. Arguments are `channelId`
 ```json
 {
   "type": "reply",
-  "error": {
-    "code": 1,
-    "message": "UNOTFOUND",
-    "stacktrace": "",
-    "data": {}
-  },
+  "error": "UNOTFOUND",
   "id": 0
 }
 ```
@@ -108,12 +103,7 @@ Attempting to join a channel currently in Test Stream mode with an invalid or mi
 ```json
 {
   "type": "reply",
-  "error": {
-    "code": 1,
-    "message": "UACCESS",
-    "stacktrace": "",
-    "data": {}
-  },
+  "error": "UACCESS",
   "id": 0
 }
 ```


### PR DESCRIPTION
I'm not sure when this changed, but these aren't objects anymore

```bash
$ wscat -c wss://chat.mixer.com
connected (press CTRL+C to quit)
< {"type":"event","event":"WelcomeEvent","data":{"server":"ba8facf2-909e-4cf7-bd57-ffbff72f6b73"}}
> {"type":"method","method":"auth","arguments":[515]}
< {"type":"reply","error":"UACCESS"}
> ^C

$ wscat -c wss://chat.mixer.com
connected (press CTRL+C to quit)
< {"type":"event","event":"WelcomeEvent","data":{"server":"1d56a661-3df3-4166-93f7-904aaeac0831"}}
> {"type":"method","method":"auth","arguments":[515,591,"invalid"]}
< {"type":"reply","error":"UNOTFOUND"}
> ^C
```